### PR TITLE
Allow for comma delimited list of URLs

### DIFF
--- a/src/main/kotlin/com/budilov/aws/lambda/ComprehendLambda.kt
+++ b/src/main/kotlin/com/budilov/aws/lambda/ComprehendLambda.kt
@@ -19,22 +19,32 @@ class ComprehendLambda : RequestHandler<ApiGatewayRequest.Input,
     override fun handleRequest(request: ApiGatewayRequest.Input?,
                                context: Context?): ApiGatewayResponse {
 
-        val url = request?.headers?.get("url")
+        val urlHeader = request?.headers?.get("url")
+        val urls = urlHeader?.split(',')
+
+        var fullText = ""
+
+        for (url in urls.orEmpty()) {
+
+            if (url != null) {
+                try {
+                    val doc = Jsoup.connect(url).get()
+                    fullText += " " + doc.body().text()
+                } catch (e: Exception) {
+                }
+
+            }
+        }
 
         var status = 400
         var response = ""
 
-        if (url != null) {
-            try {
-                val doc = Jsoup.connect(url).get()
-
-                response = Gson().toJson(ComprehendService.getAll(doc.body().text()))
-                println("response: $response")
-                status = 200
-            } catch (e: Exception) {
-                status = 400
-            }
-
+        try {
+            response = Gson().toJson(ComprehendService.getAll(fullText))
+            println("response: $response")
+            status = 200
+        } catch (e: Exception) {
+            status = 400
         }
 
         return ApiGatewayResponse(statusCode = status, body = response)


### PR DESCRIPTION
Header parameter now looks for a comma delimited list of URLs instead of only a single URL.   The future TODO of making it an actual crawler will be a better feature, but for the small testing I needed of the comprehend service this was enough for me.   

Sharing in case it is helpful.  